### PR TITLE
reload same geojson

### DIFF
--- a/docs/53.create-and-save-geojson/script.js
+++ b/docs/53.create-and-save-geojson/script.js
@@ -5,7 +5,7 @@
 
 // config map
 let config = {
-  minZoom: 7,
+  minZoom: 5,
   maxZoom: 18,
   fullscreenControl: true,
 };
@@ -62,7 +62,7 @@ const customControl = L.Control.extend({
         className: "remove link-button leaflet-bar",
       },
       {
-        title: "load gejson from file",
+        title: "load geojson from file",
         html: "<input type='file' id='geojson' class='geojson' accept='text/plain, text/json, .geojson' onchange='openFile(event)' /><label for='geojson'><svg class='icon-geojson'><use xlink:href='#icon-import'></use></svg></label>",
         className: "load link-button leaflet-bar",
       },
@@ -249,4 +249,5 @@ function openFile(event) {
     setGeojsonToMap(geojson);
   };
   reader.readAsText(input.files[0]);
+  event.target.value = null;
 }

--- a/docs/53.create-and-save-geojson/script.js
+++ b/docs/53.create-and-save-geojson/script.js
@@ -249,5 +249,6 @@ function openFile(event) {
     setGeojsonToMap(geojson);
   };
   reader.readAsText(input.files[0]);
-  event.target.value = null;
+
+  input.value = "";
 }


### PR DESCRIPTION
Issue for 53.create-and-save-geojson :
![53Before-ezgif com-video-to-gif-converter](https://github.com/tomickigrzegorz/leaflet-examples/assets/57721854/2cfd6090-045a-40d7-a371-bc7e80948f25)


Step 1: load a geojson
Step 2: remove the geojson
Step 3: reload 'same' geojson

Expected outcome: the geojson should load again.
Actual outcome: geojson doesn't load. No error logged on console.

Fix: value in event target made null.

ps: min zoom level changed to display bigger area
& gejson cosmetic fix




